### PR TITLE
Frontend issues fixes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -64,42 +64,42 @@ class App extends Component {
       const endBetaTimestamp = 1604080800000
       if (Date.now() > endBetaTimestamp) {
         return resolve(true)
-      } else {
-        let yeldBalance = await window.yeld.methods.balanceOf(window.web3.eth.defaultAccount).call()
-        const fiveYeld = await window.web3.utils.toWei('5')
-        resolve(Number(yeldBalance) >= Number(fiveYeld))
       }
+      let yeldBalance = await window.yeld.methods.balanceOf(window.web3.eth.defaultAccount).call()
+      const fiveYeld = await window.web3.utils.toWei('5')
+      resolve(Number(yeldBalance) >= Number(fiveYeld))
     })
   }
 
   setup = async () => {
-    // Create the contract instance
-    window.web3 = new MyWeb3(window.ethereum)
+    if (typeof (window.ethereum) !== 'undefined') {
+      // Create the contract instance
+      window.web3 = new MyWeb3(window.ethereum);
 
-    try {
-      await window.ethereum.enable();
-    } catch (error) {
-      console.error('You must approve this dApp to interact with it')
-    }
-    window.yeld = new window.web3.eth.Contract(yeldConfig.yeldAbi, yeldConfig.yeldAddress)
-    const account = await this.getAccount();
+      try {
+        await window.ethereum.enable();
+      } catch (error) {
+        console.error('You must approve this dApp to interact with it')
+      }
+      window.yeld = new window.web3.eth.Contract(yeldConfig.yeldAbi, yeldConfig.yeldAddress)
+      const account = await this.getAccount();
+      window.web3.eth.defaultAccount = account
 
-    window.web3.eth.defaultAccount = account
+      // Create the retirementyeld and yelddai contract instances
+      window.retirementYeld = new window.web3.eth.Contract(yeldConfig.retirementYeldAbi, yeldConfig.retirementYeldAddress)
+      window.yDAI = new window.web3.eth.Contract(yeldConfig.yDAIAbi, yeldConfig.yDAIAddress)
+      window.yTUSD = new window.web3.eth.Contract(yeldConfig.yDAIAbi, yeldConfig.yTUSDAddress)
+      window.yUSDT = new window.web3.eth.Contract(yeldConfig.yDAIAbi, yeldConfig.yUSDTAddress)
+      window.yUSDC = new window.web3.eth.Contract(yeldConfig.yDAIAbi, yeldConfig.yUSDCAddress)
 
-    // Create the retirementyeld and yelddai contract instances
-    window.retirementYeld = new window.web3.eth.Contract(yeldConfig.retirementYeldAbi, yeldConfig.retirementYeldAddress)
-    window.yDAI = new window.web3.eth.Contract(yeldConfig.yDAIAbi, yeldConfig.yDAIAddress)
-    window.yTUSD = new window.web3.eth.Contract(yeldConfig.yDAIAbi, yeldConfig.yTUSDAddress)
-    window.yUSDT = new window.web3.eth.Contract(yeldConfig.yDAIAbi, yeldConfig.yUSDTAddress)
-    window.yUSDC = new window.web3.eth.Contract(yeldConfig.yDAIAbi, yeldConfig.yUSDCAddress)
-
-    if (await this.betaTesting()) {
-      this.setState({
-        betaValid: true,
-        setupComplete: true,
-      })
-    } else {
-      this.setState({ setupComplete: true })
+      if (await this.betaTesting()) {
+        this.setState({
+          betaValid: true,
+          setupComplete: true,
+        })
+      } else {
+        this.setState({ setupComplete: true })
+      }
     }
   }
 
@@ -126,11 +126,18 @@ class App extends Component {
               <Route path="/">
                 <Header setupComplete={this.state.setupComplete} />
                 {/* <Vaults /> */}
-                {!this.state.betaValid ? (
-                  <h2 style={{ margin: 'auto' }}>You need to hold 5 YELD to use the dApp</h2>
-                ) : (
-                    <InvestSimple setupComplete={this.state.setupComplete} />
-                  )}
+                {typeof (window.ethereum) !== 'undefined' ?
+                  (!this.state.betaValid ? (
+                    <h2 style={{ margin: 'auto' }}>You need to hold 5 YELD to use the dApp</h2>
+                  ) : (
+                      <InvestSimple setupComplete={this.state.setupComplete} />
+                    ))
+                  :
+                  <h2 style={{ margin: 'auto' }}>
+                    <p style={{ marginLeft: "10px" }}>You don't have Metamask Installed or </p>
+                    <p>Your browser doesn't support Metamask</p>
+                  </h2>
+                }
                 {/* <Footer /> */}
               </Route>
             </Switch>

--- a/src/App.js
+++ b/src/App.js
@@ -46,41 +46,44 @@ class App extends Component {
     injected.isAuthorized().then(isAuthorized => {
       if (isAuthorized) {
         injected.activate()
-        .then((a) => {
-          store.setStore({ account: { address: a.account }, web3context: { library: { provider: a.provider } } })
-          emitter.emit(CONNECTION_CONNECTED)
-        })
-        .catch((e) => {
-          console.log(e)
-        })
+          .then((a) => {
+            store.setStore({ account: { address: a.account }, web3context: { library: { provider: a.provider } } })
+            emitter.emit(CONNECTION_CONNECTED)
+          })
+          .catch((e) => {
+            console.log(e)
+          })
       } else {
 
       }
     });
   }
 
-  betaTesting() {
+  betaTesting = () => {
     return new Promise(async resolve => {
       const endBetaTimestamp = 1604080800000
       if (Date.now() > endBetaTimestamp) {
         return resolve(true)
+      } else {
+        let yeldBalance = await window.yeld.methods.balanceOf(window.web3.eth.defaultAccount).call()
+        const fiveYeld = await window.web3.utils.toWei('5')
+        resolve(Number(yeldBalance) >= Number(fiveYeld))
       }
-      let yeldBalance = await window.yeld.methods.balanceOf(window.web3.eth.defaultAccount).call()
-      const fiveYeld = await window.web3.utils.toWei('5')
-      resolve(Number(yeldBalance) >= Number(fiveYeld))
     })
   }
 
-  async setup() {
+  setup = async () => {
     // Create the contract instance
     window.web3 = new MyWeb3(window.ethereum)
+
     try {
-        await window.ethereum.enable();
+      await window.ethereum.enable();
     } catch (error) {
-        console.error('You must approve this dApp to interact with it')
+      console.error('You must approve this dApp to interact with it')
     }
     window.yeld = new window.web3.eth.Contract(yeldConfig.yeldAbi, yeldConfig.yeldAddress)
-    const account = await this.getAccount()
+    const account = await this.getAccount();
+
     window.web3.eth.defaultAccount = account
 
     // Create the retirementyeld and yelddai contract instances
@@ -91,7 +94,7 @@ class App extends Component {
     window.yUSDC = new window.web3.eth.Contract(yeldConfig.yDAIAbi, yeldConfig.yUSDCAddress)
 
     if (await this.betaTesting()) {
-      this.setState({ 
+      this.setState({
         betaValid: true,
         setupComplete: true,
       })
@@ -109,7 +112,7 @@ class App extends Component {
 
   render() {
     return (
-      <MuiThemeProvider theme={ createMuiTheme(interestTheme) }>
+      <MuiThemeProvider theme={createMuiTheme(interestTheme)}>
         <CssBaseline />
         <IpfsRouter>
           <div style={{
@@ -124,10 +127,10 @@ class App extends Component {
                 <Header setupComplete={this.state.setupComplete} />
                 {/* <Vaults /> */}
                 {!this.state.betaValid ? (
-                  <h2 style={{margin: 'auto'}}>You need to hold 5 YELD to use the dApp</h2>
+                  <h2 style={{ margin: 'auto' }}>You need to hold 5 YELD to use the dApp</h2>
                 ) : (
-                  <InvestSimple setupComplete={this.state.setupComplete} />
-                )}
+                    <InvestSimple setupComplete={this.state.setupComplete} />
+                  )}
                 {/* <Footer /> */}
               </Route>
             </Switch>

--- a/src/components/investSimple/asset.jsx
+++ b/src/components/investSimple/asset.jsx
@@ -183,7 +183,7 @@ class Asset extends Component {
             variant='text'
             disabled={ loading || asset.disabled }
             color="primary"
-            onClick={ () => { this.setAmount(25) } }>
+            onClick={ () => { this.setAmount(25) } }> 
             <Typography variant={'h5'}>25%</Typography>
           </Button>
           <Button
@@ -215,7 +215,7 @@ class Asset extends Component {
           className={ classes.actionButton }
           variant="outlined"
           color="primary"
-          disabled={ loading || !account.address || asset.disabled }
+          disabled={ loading || !account.address || asset.disabled || amount <= 0 }
           onClick={ async () => {
             if(await this.betaTesting()) {
               this.onInvest()
@@ -283,7 +283,7 @@ class Asset extends Component {
           className={ classes.actionButton }
           variant="outlined"
           color="primary"
-          disabled={ loading || !account.address }
+          disabled={ loading || !account.address || redeemAmount <= 0 }
           onClick={ async () => {
             if(await this.betaTesting()) {
               this.onRedeem()
@@ -300,7 +300,7 @@ class Asset extends Component {
           style={{marginTop: '10px'}}
           variant="outlined"
           color="primary"
-          disabled={ loading || !account.address }
+          disabled={ loading || !account.address || redeemAmount <= 0 }
           onClick={async () => {
             if(await this.betaTesting()) {
               let generatedYELD

--- a/src/components/unlock/unlock.jsx
+++ b/src/components/unlock/unlock.jsx
@@ -172,7 +172,10 @@ function getLibrary(provider) {
 function onConnectionClicked(currentConnector, name, setActivatingConnector, activate) {
   const connectorsByName = store.getStore('connectorsByName')
   setActivatingConnector(currentConnector);
-  activate(connectorsByName[name]);
+  activate(connectorsByName[name], null, true)
+  .catch((_) => {
+    setActivatingConnector(undefined);
+  });
 }
 
 function onDeactivateClicked(deactivate, connector) {
@@ -187,12 +190,13 @@ function onDeactivateClicked(deactivate, connector) {
 }
 
 function MyComponent(props) {
-
   const context = useWeb3React();
   const localContext = store.getStore('web3context');
+  var connectorsByName = store.getStore('connectorsByName')
   var localConnector = null;
+
   if (localContext) {
-    localConnector = localContext.connector
+    localConnector = connectorsByName[localContext.connector]
   }
   const {
     connector,
@@ -203,7 +207,6 @@ function MyComponent(props) {
     active,
     error
   } = context;
-  var connectorsByName = store.getStore('connectorsByName')
 
   const { closeModal, t } = props
 
@@ -290,7 +293,8 @@ function MyComponent(props) {
               onClick={() => {
                 onConnectionClicked(currentConnector, name, setActivatingConnector, activate)
               }}
-              disabled={ disabled }>
+              disabled={ disabled }
+          >
               <Typography style={ {
                   margin: '0px 12px',
                   color: 'rgb(1, 1, 1)',

--- a/src/stores/connectors.jsx
+++ b/src/stores/connectors.jsx
@@ -21,6 +21,10 @@ export const injected = new InjectedConnector({
   supportedChainIds: [1, 3, 4, 5, 42]
 });
 
+export const injectedTorus = new InjectedConnector({
+  supportedChainIds: [1, 3, 4, 5, 42]
+});
+
 // export const network = new NetworkConnector({
 //   urls: { 1: RPC_URLS[1], 4: RPC_URLS[4] },
 //   defaultChainId: 1,

--- a/src/stores/store.jsx
+++ b/src/stores/store.jsx
@@ -45,6 +45,7 @@ import Web3 from 'web3';
 
 import {
   injected,
+  injectedTorus,
   walletconnect,
   walletlink,
   ledger,
@@ -605,7 +606,7 @@ class Store {
       events: [],
       connectorsByName: {
         MetaMask: injected,
-        TrustWallet: injected,
+        TrustWallet: injectedTorus,
         WalletConnect: walletconnect,
         WalletLink: walletlink,
         Ledger: ledger,


### PR DESCRIPTION
**Fixes:** https://github.com/merlox/yeld-frontend/issues/5

- [x] [CHROME] Clicking the “Stake Yeld Tokens” button displays the following error. Refresh fixes this.  Fixed in PR

- [x] [CHROME] This is also happening when you click the action and dismiss the alert by clicking cancel Fixed in PR

- [x] [CHROME] Clicking “Unstake tokens” twice causes the following error. Refresh fixes this. Fixed in PR

- [x] [CHROME] These buttons should be disabled until values within the input fields are >0.  This should be the case for ALL of the token pair types.

- [x] [CHROME] To have more control over the UI shifting away from browser alert blocks to custom modals these actions should not initiate any wallet TX if the value is 0 Fixed in PR

- [x] [CHROME] When you disconnect your wallet the staked totals and wallet balance still displays the values.  This should probably go back to 0

- [x] [CHROME] When connecting to the site via MetaMask it displays as being connected through TrustWallet as well.  Not sure if MetMask utilizes some features from TW but just wanted to document this.

- [x] [CHROME] When already connected via metamask, if you select a new wallet type the green indicators shows for the one clicked, not the one connected.
After this, you are not able to click any other wallets until you refresh or close the modal and reopen.

- [x] [SAFARI] Safari w/o wallet extension displays the following warning

@merlox Please Review.